### PR TITLE
Removed streaming plugin for performance reasons

### DIFF
--- a/js/packages/embr-chart-js/src/client.ts
+++ b/js/packages/embr-chart-js/src/client.ts
@@ -6,7 +6,6 @@ import { Chart, registerables } from 'chart.js'
 import 'chartjs-adapter-moment'
 import AnnotationPlugin from 'chartjs-plugin-annotation'
 import ZoomPlugin from 'chartjs-plugin-zoom'
-import ChartStreaming from '@robloche/chartjs-plugin-streaming'
 import {
     BoxPlotController,
     ViolinController,
@@ -51,7 +50,6 @@ Chart.register(
     BoxPlotController,
     BoxAndWiskers,
     ChartDataLabels,
-    ChartStreaming,
     ChartjsPluginStacked100,
     DendogramChart,
     DendogramController,


### PR DESCRIPTION
On a 100k point stress test, removing the streaming plugin resulted in an **increase** of 60+ fps when using the zoom plugin to pan.

Since there is no good way to currently utilize the streaming plugin on the base chart, the plugin was removed.