### PR TITLE
Remove streaming plugin

### DIFF
--- a/js/packages/embr-chart-js/src/client.ts
+++ b/js/packages/embr-chart-js/src/client.ts
@@ -13,9 +13,6 @@ Chart.register(AnnotationPlugin)
 import ZoomPlugin from 'chartjs-plugin-zoom'
 Chart.register(ZoomPlugin)
 
-import ChartStreaming from '@robloche/chartjs-plugin-streaming'
-Chart.register(ChartStreaming)
-
 import {
     BoxPlotController,
     ViolinController,


### PR DESCRIPTION
On a 100k point stress test, removing the streaming plugin resulted in an increase of 60+ fps when using the zoom plugin to pan.

Since there is no good way to currently utilize the streaming plugin on the base chart, the plugin was removed.