### PR TITLE
assembleModules must depend on signModules tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,12 +42,13 @@ val changesetPublish by tasks.registering(NpxTask::class) {
 
 val release by tasks.registering {
     group = "publishing"
-    dependsOn(zipModules, changesetVersion, changesetPublish)
+    dependsOn(tasks.build, changesetVersion, changesetPublish)
 }
 
 val assembleModules by tasks.registering(Copy::class) {
     group = "ignition module"
     inputs.files(releaseFiles)
+    dependsOn(subprojects.map { subproject -> subproject.tasks.named { it == "signModule" } })
 
     from(releaseFiles)
     destinationDir = file("build/modules")


### PR DESCRIPTION
It's unclear to me what changed. This was working before.