### PR TITLE
`toFunction`, supply global context first

### DIFF
--- a/.changeset/wise-dolls-fly.md
+++ b/.changeset/wise-dolls-fly.md
@@ -1,0 +1,5 @@
+---
+"@embr-js/utils": minor
+---
+
+`toFunction` now supplies global context first when calling the generated function. This ensures that the global context is always correct and available when function parameters are omitted.

--- a/js/utils/src/toFunction/toFunction.ts
+++ b/js/utils/src/toFunction/toFunction.ts
@@ -15,10 +15,9 @@ export default function toFunction(string: string, globals = {}) {
             const f = Function(...Object.keys(globals), body)
             return () => f(...Object.values(globals))
         } else {
-            const f = Function(...signature, ...Object.keys(globals), body)
+            const f = Function(...Object.keys(globals), ...signature, body)
             return (params: UserScriptParams = {}) => {
-                params.length === signature.length
-                return f(...Object.values(params), ...Object.values(globals))
+                return f(...Object.values(globals), ...Object.values(params))
             }
         }
     }


### PR DESCRIPTION
`toFunction` now supplies global context first when calling the generated function. This ensures that the global context is always correct and available when function parameters are omitted.