### PR TITLE
(8.1) Expose chart component's `ComponentDelegate`.

### DIFF
--- a/.changeset/seven-badgers-smoke.md
+++ b/.changeset/seven-badgers-smoke.md
@@ -1,0 +1,8 @@
+---
+'@embr-modules/charts-web': minor
+'@embr-modules/charts': minor
+---
+
+Expose chart component's `ComponentDelegate`.
+- Provide's access through `this.delegate` in all props callback functions.
+- Importantly, this allows access to the underlying charting component through `this.delegate.proxy.ref`.

--- a/libraries/javascript/perspective-client/src/components/ComponentDelegateJavaScriptProxy.ts
+++ b/libraries/javascript/perspective-client/src/components/ComponentDelegateJavaScriptProxy.ts
@@ -19,8 +19,8 @@ export type JavaScriptRunEvent = {
 }
 
 export class ComponentDelegateJavaScriptProxy<T extends object> {
-  private readonly delegate: ComponentStoreDelegate
-  private ref: T | undefined
+  readonly delegate: ComponentStoreDelegate
+  ref: T | undefined
 
   constructor(delegate: ComponentStoreDelegate, ref?: T) {
     this.delegate = delegate

--- a/modules/charts/web/src/components/apexcharts/ApexChartsComponent.tsx
+++ b/modules/charts/web/src/components/apexcharts/ApexChartsComponent.tsx
@@ -6,6 +6,7 @@ import {
   ComponentStoreDelegate,
   JsObject,
   PComponent,
+  PlainObject,
   PropertyTree,
   SizeObject,
   StyleObject,
@@ -22,7 +23,7 @@ import {
 } from '@embr-js/perspective-client'
 import { transformProps } from '@embr-js/utils'
 import { ApexChartProps, Chart } from './react/ApexCharts'
-import { ApexOptions } from 'apexcharts'
+import ApexCharts, { ApexOptions } from 'apexcharts'
 
 export const COMPONENT_TYPE = 'embr.chart.apex-charts'
 
@@ -59,7 +60,7 @@ export function ApexChartsComponent(props: ComponentProps<ChartProps>) {
 
   useEffect(() => {
     const delegate = props.store.delegate as ApexChartsComponentDelegate
-    delegate.setChart(chartRef.current ?? undefined)
+    delegate.setProxyRef(chartRef.current ?? undefined)
   }, [props.store.delegate, chartRef.current])
 
   // Lifecycle Events
@@ -82,16 +83,20 @@ export function ApexChartsComponent(props: ComponentProps<ChartProps>) {
 }
 
 class ApexChartsComponentDelegate extends ComponentStoreDelegate {
-  private jsProxy = new ComponentDelegateJavaScriptProxy(this)
+  private proxy = new ComponentDelegateJavaScriptProxy(this)
 
-  setChart(chart?: ApexCharts) {
-    this.jsProxy.setRef(chart)
+  setProxyRef(ref?: ApexCharts) {
+    this.proxy.setRef(ref)
   }
 
   handleEvent(eventName: string, eventObject: JsObject): void {
-    if (this.jsProxy.handles(eventName)) {
-      this.jsProxy.handleEvent(eventObject as JavaScriptRunEvent)
+    if (this.proxy.handles(eventName)) {
+      this.proxy.handleEvent(eventObject as JavaScriptRunEvent)
     }
+  }
+
+  mapStateToProps(): PlainObject {
+    return this
   }
 }
 

--- a/modules/charts/web/src/components/chartjs/ChartJsComponent.tsx
+++ b/modules/charts/web/src/components/chartjs/ChartJsComponent.tsx
@@ -6,6 +6,7 @@ import {
   ComponentStoreDelegate,
   JsObject,
   PComponent,
+  PlainObject,
   PropertyTree,
   SizeObject,
 } from '@inductiveautomation/perspective-client'
@@ -63,7 +64,7 @@ export function ChartJsComponent(props: ComponentProps<ChartComponentProps>) {
   // Register the chart with the component delegate
   useEffect(() => {
     const delegate = props.store.delegate as ChartJsComponentDelegate
-    delegate.setChart(chartRef.current)
+    delegate.setProxyRef(chartRef.current)
   }, [props.store.delegate, chartRef.current])
 
   // Apply transforms to the user supplied properties
@@ -111,16 +112,20 @@ export function ChartJsComponent(props: ComponentProps<ChartComponentProps>) {
 }
 
 class ChartJsComponentDelegate extends ComponentStoreDelegate {
-  private jsProxy = new ComponentDelegateJavaScriptProxy(this)
+  private proxy = new ComponentDelegateJavaScriptProxy(this)
 
-  setChart(chart?: Chart) {
-    this.jsProxy.setRef(chart)
+  setProxyRef(ref?: Chart) {
+    this.proxy.setRef(ref)
   }
 
   handleEvent(eventName: string, eventObject: JsObject) {
-    if (this.jsProxy.handles(eventName)) {
-      this.jsProxy.handleEvent(eventObject as JavaScriptRunEvent)
+    if (this.proxy.handles(eventName)) {
+      this.proxy.handleEvent(eventObject as JavaScriptRunEvent)
     }
+  }
+
+  mapStateToProps(): PlainObject {
+    return this
   }
 }
 


### PR DESCRIPTION
Expose chart component's `ComponentDelegate`.
- Provide's access through `this.delegate` in all props callback functions.
- Importantly, this allows access to the underlying charting component through `this.delegate.proxy.ref`.