### PR TITLE
Bump dev.panuszewski.typesafe-conventions from 0.7.4 to 0.9.0

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,7 +1,7 @@
 rootProject.name = "build-logic"
 
 plugins {
-    id("dev.panuszewski.typesafe-conventions") version "0.7.4"
+    id("dev.panuszewski.typesafe-conventions") version "0.9.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Bumps dev.panuszewski.typesafe-conventions from 0.7.4 to 0.9.0.

---
updated-dependencies:
- dependency-name: dev.panuszewski.typesafe-conventions dependency-version: 0.9.0 dependency-type: direct:production update-type: version-update:semver-minor ...