### PR TITLE
(8.3) `system.perspective.invokeOnQueue`

### DIFF
--- a/.changeset/slick-pillows-win.md
+++ b/.changeset/slick-pillows-win.md
@@ -1,0 +1,5 @@
+---
+'@embr-jvm/perspective-gateway': patch
+---
+
+Add utility function for creating `PyArgumentMap` for use with `AbstractScriptingFunction`.

--- a/.changeset/strong-horses-argue.md
+++ b/.changeset/strong-horses-argue.md
@@ -1,0 +1,13 @@
+---
+'@embr-modules/periscope': minor
+---
+
+Introduce `system.perspective.invokeOnQueue`.
+
+This function schedules a runnable for execution on the Perspective session’s execution queue.
+
+- The runnable must accept a single parameter representing the requested scope element.
+  - This enables interaction across sessions.
+- If `delay` is `0`, the runnable is appended to the end of the queue.
+- The optional `scope` parameter ensures the specified scope remains available at execution time.
+  - For example, `scope='view'` ensures the originating view is still active when the runnable executes.

--- a/.changeset/strong-horses-argue.md
+++ b/.changeset/strong-horses-argue.md
@@ -8,6 +8,5 @@ This function schedules a runnable for execution on the Perspective session’s 
 
 - The runnable must accept a single parameter representing the requested scope element.
   - This enables interaction across sessions.
-- If `delay` is `0`, the runnable is appended to the end of the queue.
 - The optional `scope` parameter ensures the specified scope remains available at execution time.
-  - For example, `scope='view'` ensures the originating view is still active when the runnable executes.
+  - For example, `scope='view'` ensures the runnable will only be executed if the originating view is still active.

--- a/libraries/perspective/gateway/src/main/kotlin/com/mussonindustrial/embr/perspective/gateway/model/ScriptingFunctionUtils.kt
+++ b/libraries/perspective/gateway/src/main/kotlin/com/mussonindustrial/embr/perspective/gateway/model/ScriptingFunctionUtils.kt
@@ -1,0 +1,16 @@
+package com.mussonindustrial.embr.perspective.gateway.model
+
+import com.inductiveautomation.ignition.common.script.builtin.PyArgumentMap
+import org.python.core.PyString
+
+fun getPerspectiveArgumentMap(pageId: String?, sessionId: String?): PyArgumentMap {
+
+    val args = mapOf("pageId" to pageId, "sessionId" to sessionId)
+
+    return PyArgumentMap.interpretPyArgs(
+        args.mapNotNull { arg -> arg.value?.let { PyString(it) } }.toTypedArray(),
+        args.mapNotNull { arg -> arg.value?.let { arg.key } }.toTypedArray(),
+        arrayOf("pageId", "sessionId"),
+        arrayOf(String::class.java, String::class.java),
+    )
+}

--- a/libraries/perspective/gateway/src/main/kotlin/com/mussonindustrial/embr/perspective/gateway/model/ThreadContext.kt
+++ b/libraries/perspective/gateway/src/main/kotlin/com/mussonindustrial/embr/perspective/gateway/model/ThreadContext.kt
@@ -1,5 +1,6 @@
 package com.mussonindustrial.embr.perspective.gateway.model
 
+import com.inductiveautomation.perspective.gateway.api.PerspectiveElement
 import com.inductiveautomation.perspective.gateway.model.PageModel
 import com.inductiveautomation.perspective.gateway.model.ViewModel
 import com.inductiveautomation.perspective.gateway.session.InternalSession
@@ -38,3 +39,12 @@ fun withThreadContext(threadContext: ThreadContext, block: () -> Unit) {
         set(previous)
     }
 }
+
+val PerspectiveElement.threadContext: ThreadContext
+    get() {
+        return ThreadContext(
+            this.view as? ViewModel,
+            this.page as? PageModel,
+            this.session as? InternalSession,
+        )
+    }

--- a/modules/periscope/gateway/src/main/kotlin/com/mussonindustrial/ignition/embr/periscope/PeriscopeGatewayHook.kt
+++ b/modules/periscope/gateway/src/main/kotlin/com/mussonindustrial/ignition/embr/periscope/PeriscopeGatewayHook.kt
@@ -9,6 +9,7 @@ import com.inductiveautomation.ignition.gateway.model.GatewayContext
 import com.mussonindustrial.ignition.embr.periscope.Meta.SHORT_MODULE_ID
 import com.mussonindustrial.ignition.embr.periscope.component.embedding.*
 import com.mussonindustrial.ignition.embr.periscope.scripting.JavaScriptFunctions
+import com.mussonindustrial.ignition.embr.periscope.scripting.QueueFunctions
 import java.util.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -66,6 +67,16 @@ class PeriscopeGatewayHook : AbstractGatewayModuleHook() {
         manager.addScriptModule(
             "system.perspective",
             JavaScriptFunctions(this.context),
+            PropertiesFileDocProvider(),
+        )
+        manager.addScriptModule(
+            "system.perspective",
+            QueueFunctions(this.context),
+            PropertiesFileDocProvider(),
+        )
+        manager.addScriptModule(
+            "system.perspective",
+            QueueFunctions(this.context),
             PropertiesFileDocProvider(),
         )
     }

--- a/modules/periscope/gateway/src/main/kotlin/com/mussonindustrial/ignition/embr/periscope/scripting/JavaScriptFunctions.kt
+++ b/modules/periscope/gateway/src/main/kotlin/com/mussonindustrial/ignition/embr/periscope/scripting/JavaScriptFunctions.kt
@@ -2,7 +2,6 @@ package com.mussonindustrial.ignition.embr.periscope.scripting
 
 import com.inductiveautomation.ignition.common.TypeUtilities
 import com.inductiveautomation.ignition.common.script.builtin.KeywordArgs
-import com.inductiveautomation.ignition.common.script.builtin.PyArgumentMap
 import com.inductiveautomation.ignition.common.script.hints.JythonElement
 import com.inductiveautomation.ignition.common.util.ExecutionQueue
 import com.inductiveautomation.ignition.common.util.LogUtil
@@ -12,6 +11,7 @@ import com.inductiveautomation.perspective.gateway.model.PageModel
 import com.inductiveautomation.perspective.gateway.script.AbstractScriptingFunctions
 import com.mussonindustrial.embr.common.scripting.PyArgOverloadBuilder
 import com.mussonindustrial.embr.perspective.gateway.model.ThreadContext
+import com.mussonindustrial.embr.perspective.gateway.model.getPerspectiveArgumentMap
 import com.mussonindustrial.embr.perspective.gateway.model.withThreadContext
 import com.mussonindustrial.embr.perspective.gateway.reflect.getHandlers
 import com.mussonindustrial.ignition.embr.periscope.Meta
@@ -27,7 +27,6 @@ import kotlin.reflect.typeOf
 import org.python.core.PyDictionary
 import org.python.core.PyFunction
 import org.python.core.PyObject
-import org.python.core.PyString
 
 class JavaScriptFunctions(private val context: PeriscopeGatewayContext) :
     AbstractScriptingFunctions() {
@@ -39,18 +38,6 @@ class JavaScriptFunctions(private val context: PeriscopeGatewayContext) :
 
     override fun getContext(): PerspectiveContext {
         return context.perspectiveContext
-    }
-
-    private fun getPerspectiveArgumentMap(pageId: String?, sessionId: String?): PyArgumentMap {
-
-        val args = mapOf("pageId" to pageId, "sessionId" to sessionId)
-
-        return PyArgumentMap.interpretPyArgs(
-            args.mapNotNull { arg -> arg.value?.let { PyString(it) } }.toTypedArray(),
-            args.mapNotNull { arg -> arg.value?.let { arg.key } }.toTypedArray(),
-            arrayOf("pageId", "sessionId"),
-            arrayOf(String::class.java, String::class.java),
-        )
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/modules/periscope/gateway/src/main/kotlin/com/mussonindustrial/ignition/embr/periscope/scripting/QueueFunctions.kt
+++ b/modules/periscope/gateway/src/main/kotlin/com/mussonindustrial/ignition/embr/periscope/scripting/QueueFunctions.kt
@@ -1,0 +1,128 @@
+package com.mussonindustrial.ignition.embr.periscope.scripting
+
+import com.inductiveautomation.ignition.common.TypeUtilities
+import com.inductiveautomation.ignition.common.script.builtin.KeywordArgs
+import com.inductiveautomation.ignition.common.script.hints.JythonElement
+import com.inductiveautomation.ignition.common.util.ExecutionQueue
+import com.inductiveautomation.ignition.common.util.LogUtil
+import com.inductiveautomation.perspective.gateway.api.Page
+import com.inductiveautomation.perspective.gateway.api.PerspectiveContext
+import com.inductiveautomation.perspective.gateway.api.PerspectiveElement
+import com.inductiveautomation.perspective.gateway.api.Session
+import com.inductiveautomation.perspective.gateway.model.ViewModel
+import com.inductiveautomation.perspective.gateway.script.AbstractScriptingFunctions
+import com.inductiveautomation.perspective.gateway.script.PageScriptWrapper
+import com.inductiveautomation.perspective.gateway.script.PropertyTreeOwnerScriptWrapper
+import com.inductiveautomation.perspective.gateway.script.SessionScriptWrapper
+import com.inductiveautomation.perspective.gateway.script.ViewModelScriptWrapper
+import com.mussonindustrial.embr.common.scripting.PyArgOverloadBuilder
+import com.mussonindustrial.embr.perspective.gateway.model.ThreadContext
+import com.mussonindustrial.embr.perspective.gateway.model.getPerspectiveArgumentMap
+import com.mussonindustrial.embr.perspective.gateway.model.threadContext
+import com.mussonindustrial.embr.perspective.gateway.model.withThreadContext
+import com.mussonindustrial.ignition.embr.periscope.Meta
+import com.mussonindustrial.ignition.embr.periscope.PeriscopeGatewayContext
+import java.util.concurrent.*
+import kotlin.reflect.typeOf
+import org.python.core.PyFunction
+import org.python.core.PyObject
+
+class QueueFunctions(private val context: PeriscopeGatewayContext) : AbstractScriptingFunctions() {
+
+    private val log = LogUtil.getModuleLogger(Meta.SHORT_MODULE_ID, "QueueFunctions")
+    private val overloads = ScriptOverloads()
+
+    override fun getContext(): PerspectiveContext {
+        return context.perspectiveContext
+    }
+
+    private fun ExecutionQueue.schedule(
+        executorService: ScheduledExecutorService,
+        delay: Long,
+        unit: TimeUnit,
+        block: () -> Unit,
+    ) {
+        executorService.schedule({ this.submit(block) }, delay, unit)
+    }
+
+    private fun invokeOnQueue(
+        function: PyFunction,
+        delay: Long,
+        scope: String,
+        sessionId: String?,
+        pageId: String?,
+    ) {
+
+        val originalThreadContext = ThreadContext.get()
+        val operation: (PerspectiveElement) -> Unit = { element ->
+            element.session.queue().schedule(
+                element.session.perspectiveContext.scheduler,
+                delay,
+                TimeUnit.MILLISECONDS,
+            ) {
+                try {
+                    if (!element.isRunning) {
+                        log.trace("Lifecycle object not running: ${element.name}")
+                        return@schedule
+                    }
+
+                    val wrappedElement =
+                        when (element) {
+                            is ViewModel -> ViewModelScriptWrapper(element)
+                            is Page -> PageScriptWrapper(element)
+                            is Session -> SessionScriptWrapper(element)
+                            else -> PropertyTreeOwnerScriptWrapper(element)
+                        }
+
+                    withThreadContext(element.threadContext) {
+                        element.session.scriptManager.runFunction(function, wrappedElement)
+                    }
+                } catch (error: Exception) {
+                    originalThreadContext.view.get()?.mdcSetup()
+                    element.session.sendErrorToDesigner(error.message, error)
+                    element.session.logger.error("Exception occurred on Perspective queue.", error)
+                    originalThreadContext.view.get()?.mdcTeardown()
+                    throw error
+                }
+            }
+        }
+
+        when (scope) {
+            "view" -> operateOnView(operation)
+            "page" -> operateOnPage(getPerspectiveArgumentMap(pageId, sessionId), operation)
+            "session" -> operateOnSession(getPerspectiveArgumentMap(pageId, sessionId), operation)
+            else -> throw IllegalArgumentException("Invalid scope \"$scope\".")
+        }
+    }
+
+    inner class ScriptOverloads {
+        val queueSubmit =
+            PyArgOverloadBuilder<Unit>()
+                .setName("invokeOnQueue")
+                .addOverload(
+                    {
+                        val function = it["function"] as PyFunction
+                        val delay = TypeUtilities.toLong(it["delay"] ?: 0)
+                        val scope = it["scope"] as? String ?: "view"
+                        val sessionId = it["sessionId"] as? String
+                        val pageId = it["pageId"] as? String
+                        invokeOnQueue(function, delay, scope, sessionId, pageId)
+                    },
+                    "function" to typeOf<PyFunction>(),
+                    "delay" to typeOf<Long?>(),
+                    "scope" to typeOf<String?>(),
+                    "sessionId" to typeOf<String?>(),
+                    "pageId" to typeOf<String?>(),
+                )
+                .build()
+    }
+
+    @JythonElement(docBundlePrefix = "${Meta.BUNDLE_PREFIX}.script")
+    @KeywordArgs(
+        names = ["function", "delay", "scope", "sessionId", "pageId"],
+        types = [PyFunction::class, Long::class, String::class, String::class, String::class],
+    )
+    @Suppress("unused")
+    fun invokeOnQueue(args: Array<PyObject>, keywords: Array<String>) =
+        overloads.queueSubmit.call(args, keywords)
+}

--- a/modules/periscope/gateway/src/main/resources/localization.properties
+++ b/modules/periscope/gateway/src/main/resources/localization.properties
@@ -1,17 +1,29 @@
-script.common-param.sessionId=Optional. Identifier of the session to target. If omitted, current session will be used automatically.
-script.common-param.pageId=Optional. Identifier of the page to target. If omitted, current page will be used automatically.
+script.common-param.sessionId=Identifier of the session to target. If omitted, current session will be used automatically.
+script.common-param.pageId=Identifier of the page to target. If omitted, current page will be used automatically.
 
 script.runJavaScriptBlocking.desc=Run JavaScript code on the client and block for the result.
 script.runJavaScriptBlocking.param.function=JavaScript function to run. Should be formatted as an arrow function. You may return a promise and resolve it later.<br><br>Example:<br><code>() => console.log('runJavaScriptBlocking')</code>
-script.runJavaScriptBlocking.param.args=Optional. Dictionary of arguments to use when calling the function. The keys of the dictionary should match the names of the arrow function arguments.
+script.runJavaScriptBlocking.param.args=Dictionary of arguments to use when calling the function. The keys of the dictionary should match the names of the arrow function arguments.
+script.runJavaScriptBlocking.param.args.optional=true
+script.runJavaScriptBlocking.sessionId.optional=true
+script.runJavaScriptBlocking.pageId.optional=true
 script.runJavaScriptBlocking.returns=Return value of JavaScript function.
 
 script.runJavaScriptAsync.desc=Asynchronously run JavaScript code on the client.
 script.runJavaScriptAsync.param.function=JavaScript function to run. Should be formatted as an arrow function. You may return a promise and resolve it later.<br><br>Example:<code>`() => console.log('runJavaScriptAsync')</code>
-script.runJavaScriptAsync.param.args=Optional. Dictionary of arguments to use when calling the function. The keys of the dictionary should match the names of the arrow function arguments.
+script.runJavaScriptAsync.param.args=Dictionary of arguments to use when calling the function. The keys of the dictionary should match the names of the arrow function arguments.
+script.runJavaScriptAsync.param.args.optional=true
+script.runJavaScriptAsync.sessionId.optional=true
+script.runJavaScriptAsync.pageId.optional=true
 script.runJavaScriptAsync.param.callback=Function to run once the function has returned/resolved. Should take a single parameter containing the result of the function.
 
 script.invokeOnQueue.desc=Run a function on a Perspective execution queue, with an optional delay.
 script.invokeOnQueue.param.function=Python function to run. Should be a function reference that takes a single "scope" parameter.
-script.invokeOnQueue.param.delay=Optional. Time in milliseconds before running the function.
-script.invokeOnQueue.param.scope=Optional. Lifecycle scope. If specified, must be "session", "page", or "view", otherwise the default will be "view".
+script.invokeOnQueue.param.delay=Time in milliseconds before running the function.
+script.invokeOnQueue.param.delay.optional=true
+script.invokeOnQueue.param.delay.default=0
+script.invokeOnQueue.param.scope=Lifecycle scope. If specified, must be "session", "page", or "view", otherwise the default will be "view".
+script.invokeOnQueue.param.scope.optional=true
+script.invokeOnQueue.param.scope.default=view
+script.invokeOnQueue.sessionId.optional=true
+script.invokeOnQueue.pageId.optional=true

--- a/modules/periscope/gateway/src/main/resources/localization.properties
+++ b/modules/periscope/gateway/src/main/resources/localization.properties
@@ -10,3 +10,8 @@ script.runJavaScriptAsync.desc=Asynchronously run JavaScript code on the client.
 script.runJavaScriptAsync.param.function=JavaScript function to run. Should be formatted as an arrow function. You may return a promise and resolve it later.<br><br>Example:<code>`() => console.log('runJavaScriptAsync')</code>
 script.runJavaScriptAsync.param.args=Optional. Dictionary of arguments to use when calling the function. The keys of the dictionary should match the names of the arrow function arguments.
 script.runJavaScriptAsync.param.callback=Function to run once the function has returned/resolved. Should take a single parameter containing the result of the function.
+
+script.invokeOnQueue.desc=Run a function on a Perspective execution queue, with an optional delay.
+script.invokeOnQueue.param.function=Python function to run. Should be a function reference that takes a single "scope" parameter.
+script.invokeOnQueue.param.delay=Optional. Time in milliseconds before running the function.
+script.invokeOnQueue.param.scope=Optional. Lifecycle scope. If specified, must be "session", "page", or "view", otherwise the default will be "view".


### PR DESCRIPTION
Introduce `system.perspective.invokeOnQueue`.

This function schedules a runnable for execution on the Perspective session’s execution queue.

- The runnable must accept a single parameter representing the requested scope element.
  - This enables interaction across sessions.
- The optional `scope` parameter ensures the specified scope remains available at execution time.
  - For example, `scope='view'` ensures the runnable will only be executed if the originating view is still active.