### PR TITLE
(8.3) Charts - `ApexCharts` : Change default `updateSyncedCharts` behavior to `false`

### DIFF
--- a/.changeset/clear-sloths-enter.md
+++ b/.changeset/clear-sloths-enter.md
@@ -1,0 +1,6 @@
+---
+'@embr-modules/charts-web': patch
+'@embr-modules/charts': patch
+---
+
+(ApexCharts) Change `updateOptions` option `updateSyncedCharts` to `false`.

--- a/.changeset/khaki-tigers-sort.md
+++ b/.changeset/khaki-tigers-sort.md
@@ -1,0 +1,9 @@
+---
+'@embr-modules/charts-web': patch
+'@embr-modules/charts': patch
+---
+
+(ApexCharts) Re-draw the chart when its identity changes (`options.chart.id` or `options.chart.group`).
+- ApexCharts expects a chart's identity to remain constant through its lifecycle. This conflicts with initial values on Perspective bindings.
+- This change forces a re-draw of a chart whenever its identity changes.
+- This resolves #556.

--- a/modules/charts/web/src/components/apexcharts/react/ApexCharts.tsx
+++ b/modules/charts/web/src/components/apexcharts/react/ApexCharts.tsx
@@ -48,6 +48,12 @@ function ApexChartsComponent(
   const chartRef = useRef<ApexCharts | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
+  const identity = [
+    props.options.chart?.id ?? '',
+    props.options.chart?.group ?? '',
+    type,
+  ].join('-')
+
   const chartOptions = useMemo(() => {
     return merge(options, {
       chart: {
@@ -79,7 +85,7 @@ function ApexChartsComponent(
 
   useEffect(() => {
     if (!redraw && chartRef.current && chartOptions) {
-      void chartRef.current.updateOptions(chartOptions, false, false, true)
+      void chartRef.current.updateOptions(chartOptions, false, false, false)
     }
   }, [redraw, chartOptions])
 
@@ -102,8 +108,8 @@ function ApexChartsComponent(
     if (!chartRef.current) return
 
     destroyChart()
-    setTimeout(renderChart)
-  }, [type])
+    renderChart()
+  }, [identity])
 
   useEffect(() => {
     renderChart()


### PR DESCRIPTION
Resolves #566.