### PR TITLE
(8.1) Periscope, Recursive `self` reference search

### DIFF
--- a/.changeset/spotty-rivers-drum.md
+++ b/.changeset/spotty-rivers-drum.md
@@ -1,0 +1,5 @@
+---
+'@embr-jvm/perspective-gateway': patch
+---
+
+`PyFrame.getComponentModelScriptWrapper`: Recursively search for `self` items in the frame stack. Resolves #582.

--- a/libraries/perspective/gateway/src/main/kotlin/com/mussonindustrial/embr/perspective/gateway/reflect/ComponentModel.kt
+++ b/libraries/perspective/gateway/src/main/kotlin/com/mussonindustrial/embr/perspective/gateway/reflect/ComponentModel.kt
@@ -4,12 +4,22 @@ import com.inductiveautomation.perspective.gateway.model.ComponentModel
 import com.inductiveautomation.perspective.gateway.script.ComponentModelScriptWrapper
 import com.mussonindustrial.embr.common.reflect.getPrivateProperty
 import org.python.core.PyFrame
-import org.python.core.PyString
 
 fun ComponentModelScriptWrapper.getComponentModel(): ComponentModel {
     return this.getPrivateProperty("componentModel") as ComponentModel
 }
 
 fun PyFrame.getComponentModelScriptWrapper(name: String = "self"): ComponentModelScriptWrapper? {
-    return this.locals.__getitem__(PyString(name)) as? ComponentModelScriptWrapper ?: return null
+    val key = name.intern()
+    var frame: PyFrame? = this
+
+    while (frame != null) {
+        (frame.locals.__finditem__(key) as? ComponentModelScriptWrapper)?.let {
+            return it
+        }
+
+        frame = frame.f_back
+    }
+
+    return null
 }


### PR DESCRIPTION
`PyFrame.getComponentModelScriptWrapper`: Recursively search for `self` items in the frame stack. 
Resolves #582.